### PR TITLE
Remove tfe version pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Terraform run will fail.
 
 | Name | Version |
 |------|---------|
-| tfe | ~> 0.12 |
+| tfe | n/a |
 
 ## Inputs
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,3 @@
-provider "tfe" {
-  version = "~> 0.12"
-}
-
 terraform {
   required_version = "~> 0.12.0"
 }


### PR DESCRIPTION
In retrospect this was a bad idea as the pinning should via the plan/module consuming this module instead of in the module, unless the module requires a specific version.