### PR TITLE
Add global_remote_state configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,17 +3,16 @@ locals {
 }
 
 resource "tfe_workspace" "default" {
-  name                  = var.name
-  organization          = var.terraform_organization
-  agent_pool_id         = var.agent_pool_id
-  auto_apply            = var.auto_apply
-  execution_mode        = var.execution_mode
-  file_triggers_enabled = var.file_triggers_enabled
-  ssh_key_id            = var.ssh_key_id
-  terraform_version     = var.terraform_version
-  trigger_prefixes      = var.trigger_prefixes
-  queue_all_runs        = true
-  working_directory     = var.working_directory
+  name                      = var.name
+  organization              = var.terraform_organization
+  auto_apply                = var.auto_apply
+  file_triggers_enabled     = var.file_triggers_enabled
+  terraform_version         = var.terraform_version
+  trigger_prefixes          = var.trigger_prefixes
+  global_remote_state       = var.global_remote_state
+  queue_all_runs            = true
+  remote_state_consumer_ids = var.remote_state_consumer_ids
+  working_directory         = var.working_directory
 
   dynamic "vcs_repo" {
     for_each = local.connect_vcs_repo

--- a/variables.tf
+++ b/variables.tf
@@ -45,7 +45,6 @@ variable "execution_mode" {
   description = "Which execution mode to use"
 }
 
-
 variable "file_triggers_enabled" {
   type        = bool
   default     = true
@@ -58,9 +57,21 @@ variable "oauth_token_id" {
   description = "The OAuth token ID of the VCS provider"
 }
 
-variable "repository_identifier" {
+variable "global_remote_state" {
+  type        = bool
+  default     = null
+  description = "Allow all workspaces in the organization to read the state of this workspace"
+}
+
+variable "oauth_token_id" {
   type        = string
   description = "The VCS repository to connect the workspace to. E.g. for GitHub this is: <organization>/<repository>"
+}
+
+variable "remote_state_consumer_ids" {
+  type        = set(string)
+  default     = null
+  description = "A set of workspace IDs set as explicit remote state consumers for this workspace"
 }
 
 variable "sensitive_env_variables" {


### PR DESCRIPTION
Add the `global_remote_state` and `remote_state_consumer_ids` configuration (to allow other Workspaces to read the state).