### PR TITLE
Add global_remote_state configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ Terraform run will fail.
 | clear\_text\_terraform\_variables | An optional map with clear text Terraform variables | `map(string)` | `{}` | no |
 | execution\_mode | Which execution mode to use | `string` | `"remote"` | no |
 | file\_triggers\_enabled | Whether to filter runs based on the changed files in a VCS push | `bool` | `true` | no |
+| global\_remote\_state | Allow all workspaces in the organization to read the state of this workspace | `bool` | `null` | no |
 | oauth\_token\_id | The OAuth token ID of the VCS provider | `string` | `null` | no |
+| remote\_state\_consumer\_ids | A set of workspace IDs set as explicit remote state consumers for this workspace | `set(string)` | `null` | no |
 | sensitive\_env\_variables | An optional map with sensitive environment variables | `map(string)` | `{}` | no |
 | sensitive\_hcl\_variables | An optional map with sensitive HCL Terraform variables | <pre>map(object({<br>    sensitive = string<br>  }))</pre> | `{}` | no |
 | sensitive\_terraform\_variables | An optional map with sensitive Terraform variables | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -3,17 +3,19 @@ locals {
 }
 
 resource "tfe_workspace" "default" {
-  name                  = var.name
-  organization          = var.terraform_organization
-  agent_pool_id         = var.agent_pool_id
-  auto_apply            = var.auto_apply
-  execution_mode        = var.execution_mode
-  file_triggers_enabled = var.file_triggers_enabled
-  ssh_key_id            = var.ssh_key_id
-  terraform_version     = var.terraform_version
-  trigger_prefixes      = var.trigger_prefixes
-  queue_all_runs        = true
-  working_directory     = var.working_directory
+  name                      = var.name
+  organization              = var.terraform_organization
+  agent_pool_id             = var.agent_pool_id
+  auto_apply                = var.auto_apply
+  execution_mode            = var.execution_mode
+  file_triggers_enabled     = var.file_triggers_enabled
+  global_remote_state       = var.global_remote_state
+  remote_state_consumer_ids = var.remote_state_consumer_ids
+  ssh_key_id                = var.ssh_key_id
+  terraform_version         = var.terraform_version
+  trigger_prefixes          = var.trigger_prefixes
+  queue_all_runs            = true
+  working_directory         = var.working_directory
 
   dynamic "vcs_repo" {
     for_each = local.connect_vcs_repo

--- a/variables.tf
+++ b/variables.tf
@@ -45,17 +45,28 @@ variable "execution_mode" {
   description = "Which execution mode to use"
 }
 
-
 variable "file_triggers_enabled" {
   type        = bool
   default     = true
   description = "Whether to filter runs based on the changed files in a VCS push"
 }
 
+variable "global_remote_state" {
+  type        = bool
+  default     = null
+  description = "Allow all workspaces in the organization to read the state of this workspace"
+}
+
 variable "oauth_token_id" {
   type        = string
   default     = null
   description = "The OAuth token ID of the VCS provider"
+}
+
+variable "remote_state_consumer_ids" {
+  type        = set(string)
+  default     = null
+  description = "A set of workspace IDs set as explicit remote state consumers for this workspace"
 }
 
 variable "repository_identifier" {


### PR DESCRIPTION
Add the `global_remote_state` and `remote_state_consumer_ids` configuration (to allow other Workspaces to read the state).

Based on the same change made in the AWS version of this module (https://github.com/schubergphilis/terraform-aws-mcaf-workspace/pull/37)