### PR TITLE
Add workspace tag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Terraform run will fail.
 | terraform\_version | The version of Terraform to use for this workspace | `string` | `"latest"` | no |
 | trigger\_prefixes | List of repository-root-relative paths which should be tracked for changes | `list(string)` | <pre>[<br>  "modules"<br>]</pre> | no |
 | working\_directory | A relative path that Terraform will execute within | `string` | `"terraform"` | no |
+| workspace\_tags | A list of tag names for this workspace. Note that tags must only contain lowercase letters, numbers, colons, or hyphens | `list(string)` | `null` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,7 @@ resource "tfe_workspace" "default" {
   global_remote_state       = var.global_remote_state
   remote_state_consumer_ids = var.remote_state_consumer_ids
   ssh_key_id                = var.ssh_key_id
+  tag_names                 = var.workspace_tags
   terraform_version         = var.terraform_version
   trigger_prefixes          = var.trigger_prefixes
   queue_all_runs            = true

--- a/variables.tf
+++ b/variables.tf
@@ -157,7 +157,7 @@ variable "workspace_tags" {
   description = "A list of tag names for this workspace. Note that tags must only contain lowercase letters, numbers, colons, or hyphens"
 
   validation {
-    condition     = alltrue([for workspace_tag in var.workspace_tags : can(regex("^[-:a-z0-9]$", workspace_tag))])
+    condition     = alltrue([for workspace_tag in var.workspace_tags : can(regex("[-:a-z0-9]", workspace_tag))])
     error_message = "One or more tags are not in the correct format (lowercase letters, numbers, colons, or hyphens)"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -150,3 +150,14 @@ variable "working_directory" {
   default     = "terraform"
   description = "A relative path that Terraform will execute within"
 }
+
+variable "workspace_tags" {
+  type        = list(string)
+  default     = null
+  description = "A list of tag names for this workspace. Note that tags must only contain lowercase letters, numbers, colons, or hyphens"
+
+  validation {
+    condition     = alltrue([for workspace_tag in var.workspace_tags : can(regex("^[-:a-z0-9]$", workspace_tag))])
+    error_message = "One or more tags are not in the correct format (lowercase letters, numbers, colons, or hyphens)"
+  }
+}


### PR DESCRIPTION
This PR adds support for adding tags to workspaces.

https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/workspace#tag_names

See also: https://github.com/schubergphilis/terraform-aws-mcaf-workspace/pull/50