### PR TITLE
Fix `var.workspace_tags`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Terraform run will fail.
 | terraform\_version | The version of Terraform to use for this workspace | `string` | `"latest"` | no |
 | trigger\_prefixes | List of repository-root-relative paths which should be tracked for changes | `list(string)` | <pre>[<br>  "modules"<br>]</pre> | no |
 | working\_directory | A relative path that Terraform will execute within | `string` | `"terraform"` | no |
-| workspace\_tags | A list of tag names for this workspace. Note that tags must only contain lowercase letters, numbers, colons, or hyphens | `list(string)` | `null` | no |
+| workspace\_tags | A list of tag names for this workspace. Note that tags must only contain lowercase letters, numbers, colons, or hyphens | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/variables.tf
+++ b/variables.tf
@@ -153,7 +153,7 @@ variable "working_directory" {
 
 variable "workspace_tags" {
   type        = list(string)
-  default     = null
+  default     = []
   description = "A list of tag names for this workspace. Note that tags must only contain lowercase letters, numbers, colons, or hyphens"
 
   validation {


### PR DESCRIPTION
If not set, we get this error:

```
A null value cannot be used as the collection in a 'for' expression.
```

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
