### PR TITLE
fix: Change connect_vcs_repo calculation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  connect_vcs_repo = (var.oauth_token_id == null || var.github_app_installation_id == null) || var.repository_identifier == null ? {} : { create = true }
+  connect_vcs_repo = var.repository_identifier != null ? { create = true } : {}
 }
 
 resource "tfe_workspace" "default" {


### PR DESCRIPTION
This PR changes the calculation of the `connect_vcs_repo` local. 

This is done because in our setup our VCS got disconnected from the workspace after upgrading. This happens because the new variable `github_app_installation_id` is null.

Looking at the PR where it comes from (https://github.com/schubergphilis/terraform-tfe-mcaf-workspace/pull/14) this is not the wanted behaviour. So simplify the calculation. If a repository is given, set the VCS