### PR TITLE
feature: Support GitHub app for VCS connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_name"></a> [name](#input\_name) | A name for the Terraform workspace | `string` | n/a | yes |
-| <a name="input_oauth_token_id"></a> [oauth\_token\_id](#input\_oauth\_token\_id) | The OAuth token ID of the VCS provider | `string` | n/a | yes |
 | <a name="input_terraform_organization"></a> [terraform\_organization](#input\_terraform\_organization) | The Terraform Enterprise organization to create the workspace in | `string` | n/a | yes |
 | <a name="input_agent_pool_id"></a> [agent\_pool\_id](#input\_agent\_pool\_id) | Agent pool ID, requires "execution\_mode" to be set to agent | `string` | `null` | no |
 | <a name="input_allow_destroy_plan"></a> [allow\_destroy\_plan](#input\_allow\_destroy\_plan) | Whether destroy plans can be queued on the workspace | `bool` | `true` | no |
@@ -60,8 +59,10 @@ No modules.
 | <a name="input_description"></a> [description](#input\_description) | A description for the workspace | `string` | `null` | no |
 | <a name="input_execution_mode"></a> [execution\_mode](#input\_execution\_mode) | Which execution mode to use | `string` | `"remote"` | no |
 | <a name="input_file_triggers_enabled"></a> [file\_triggers\_enabled](#input\_file\_triggers\_enabled) | Whether to filter runs based on the changed files in a VCS push | `bool` | `true` | no |
+| <a name="input_github_app_installation_id"></a> [github\_app\_installation\_id](#input\_github\_app\_installation\_id) | The GitHub App installation ID to use | `string` | `null` | no |
 | <a name="input_global_remote_state"></a> [global\_remote\_state](#input\_global\_remote\_state) | Allow all workspaces in the organization to read the state of this workspace | `bool` | `null` | no |
 | <a name="input_notification_configuration"></a> [notification\_configuration](#input\_notification\_configuration) | Notification configuration, using name as key and config as value | <pre>map(object({<br>    destination_type = string<br>    enabled          = optional(bool, true)<br>    url              = string<br>    triggers = optional(list(string), [<br>      "run:created",<br>      "run:planning",<br>      "run:needs_attention",<br>      "run:applying",<br>      "run:completed",<br>      "run:errored",<br>    ])<br>  }))</pre> | `{}` | no |
+| <a name="input_oauth_token_id"></a> [oauth\_token\_id](#input\_oauth\_token\_id) | The OAuth token ID of the VCS provider | `string` | `null` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of the project where the workspace should be created | `string` | `null` | no |
 | <a name="input_queue_all_runs"></a> [queue\_all\_runs](#input\_queue\_all\_runs) | When set to false no initial run is queued and all runs triggered by a webhook will not be queued, necessary if you need to set variable sets after creation. | `bool` | `true` | no |
 | <a name="input_remote_state_consumer_ids"></a> [remote\_state\_consumer\_ids](#input\_remote\_state\_consumer\_ids) | A set of workspace IDs set as explicit remote state consumers for this workspace | `set(string)` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -30,10 +30,18 @@ resource "tfe_workspace" "default" {
     for_each = local.connect_vcs_repo
 
     content {
-      identifier         = var.repository_identifier
-      branch             = var.branch
-      ingress_submodules = false
-      oauth_token_id     = var.oauth_token_id
+      branch                     = var.branch
+      github_app_installation_id = var.github_app_installation_id
+      identifier                 = var.repository_identifier
+      ingress_submodules         = false
+      oauth_token_id             = var.oauth_token_id
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = can(local.connect_vcs_repo.true) ? (var.github_app_installation_id != null || var.oauth_token_id != null) : true
+      error_message = "VCS repository requires either a GitHub App installation ID or an OAuth token ID"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -81,6 +81,12 @@ variable "file_triggers_enabled" {
   description = "Whether to filter runs based on the changed files in a VCS push"
 }
 
+variable "github_app_installation_id" {
+  type        = string
+  default     = null
+  description = "The GitHub App installation ID to use"
+}
+
 variable "global_remote_state" {
   type        = bool
   default     = null
@@ -113,6 +119,7 @@ variable "notification_configuration" {
 
 variable "oauth_token_id" {
   type        = string
+  default     = null
   description = "The OAuth token ID of the VCS provider"
 }
 


### PR DESCRIPTION
Adds GitHub app installation ID instead of a VCS provider Id to connect workspaces to repositories.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
