### PR TITLE
fix: invalid for_each argument error in TF 1.10.0+ when notification configuration url is marked sensitive

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -54,13 +54,13 @@ resource "tfe_workspace_settings" "default" {
 }
 
 resource "tfe_notification_configuration" "default" {
-  for_each = var.notification_configuration
+  for_each = nonsensitive(toset(keys(var.notification_configuration)))
 
   name             = each.key
-  destination_type = each.value.destination_type
-  enabled          = each.value.enabled
-  triggers         = each.value.triggers
-  url              = each.value.url
+  destination_type = var.notification_configuration[each.key].destination_type
+  enabled          = var.notification_configuration[each.key].enabled
+  triggers         = var.notification_configuration[each.key].triggers
+  url              = var.notification_configuration[each.key].url
   workspace_id     = tfe_workspace.default.id
 }
 

--- a/main.tf
+++ b/main.tf
@@ -57,9 +57,9 @@ resource "tfe_notification_configuration" "default" {
   for_each = nonsensitive(toset(keys(var.notification_configuration)))
 
   name             = each.key
-  destination_type = var.notification_configuration[each.key].destination_type
-  enabled          = var.notification_configuration[each.key].enabled
-  triggers         = var.notification_configuration[each.key].triggers
+  destination_type = nonsensitive(var.notification_configuration[each.key].destination_type)
+  enabled          = nonsensitive(var.notification_configuration[each.key].enabled)
+  triggers         = nonsensitive(var.notification_configuration[each.key].triggers)
   url              = var.notification_configuration[each.key].url
   workspace_id     = tfe_workspace.default.id
 }


### PR DESCRIPTION
There is a behaviour change since Terraform 1.10.0. If a variable in an object is marked as sensitive the whole object is marked as sensitive.

When the notification url is sensitive the plan on `tfe_notification_configuration.default` fails because of `Invalid for_each argument - var.notification_configuration has a sensitive value` error.

This circumvents the issues by iterating over set of keys marked as nonsensitive.
Also forces destination_type, enabled and triggers as nonsensitive since those are based on fixed values and won't be sensitive