### PR TITLE
feat: Add `github-vcs` and `gitlab-vcs` submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # terraform-tfe-mcaf-workspace
 
-MCAF Terraform module to create and manage a Terraform Cloud workspace.
-
-With default options Terraform will also create and manage a GitHub repository and attach it to the Terraform Cloud
-workspace. If the `create_repository` option is set to `false`, the GitHub repository should already exist or the
-Terraform run will fail.
+MCAF Terraform module to create and manage an HCP Terraform workspace.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ No modules.
 | [tfe_workspace_settings.default](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/workspace_settings) | resource |
 | [tfe_workspace_variable_set.default](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/workspace_variable_set) | resource |
 | [tfe_team.default](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/team) | data source |
+| [tfe_variable_set.default](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/variable_set) | data source |
 
 ## Inputs
 
@@ -71,8 +72,9 @@ No modules.
 | <a name="input_team_access"></a> [team\_access](#input\_team\_access) | Map of team names and either type of fixed access or custom permissions to assign | <pre>map(object({<br/>    access = optional(string, null),<br/>    permissions = optional(object({<br/>      run_tasks         = bool<br/>      runs              = string<br/>      sentinel_mocks    = string<br/>      state_versions    = string<br/>      variables         = string<br/>      workspace_locking = bool<br/>    }), null)<br/>  }))</pre> | `{}` | no |
 | <a name="input_terraform_version"></a> [terraform\_version](#input\_terraform\_version) | The version of Terraform to use for this workspace | `string` | `"latest"` | no |
 | <a name="input_trigger_patterns"></a> [trigger\_patterns](#input\_trigger\_patterns) | List of glob patterns that describe the files Terraform Cloud monitors for changes. Trigger patterns are always appended to the root directory of the repository. Mutually exclusive with trigger-prefixes | `list(string)` | <pre>[<br/>  "modules/**/*"<br/>]</pre> | no |
-| <a name="input_trigger_prefixes"></a> [trigger\_prefixes](#input\_trigger\_prefixes) | List of repository-root-relative paths which should be tracked for changes | `list(string)` | `null` | no |
-| <a name="input_variable_set_ids"></a> [variable\_set\_ids](#input\_variable\_set\_ids) | Map of variable set ids to attach to the workspace | `map(string)` | `{}` | no |
+| <a name="input_trigger_prefixes"></a> [trigger\_prefixes](#input\_trigger\_prefixes) | (**DEPRECATED**) List of repository-root-relative paths which should be tracked for changes | `list(string)` | `null` | no |
+| <a name="input_variable_set_ids"></a> [variable\_set\_ids](#input\_variable\_set\_ids) | Map of variable set IDs to attach to the workspace | `map(string)` | `{}` | no |
+| <a name="input_variable_set_names"></a> [variable\_set\_names](#input\_variable\_set\_names) | Set of variable set names to attach to the workspace | `set(string)` | `[]` | no |
 | <a name="input_working_directory"></a> [working\_directory](#input\_working\_directory) | A relative path that Terraform will execute within | `string` | `"terraform"` | no |
 | <a name="input_workspace_tags"></a> [workspace\_tags](#input\_workspace\_tags) | A list of tag names for this workspace. Note that tags must only contain lowercase letters, numbers, colons, or hyphens | `list(string)` | `null` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,18 @@
 locals {
   connect_vcs_repo = var.repository_identifier != null ? { create = true } : {}
+
+  # Use var.variable_set_ids if set, otherwise use var.variable_set_names to get variable set IDs.
+  variable_set_ids = (
+    length(var.variable_set_ids) > 0 ? var.variable_set_ids :
+    { for vs in data.tfe_variable_set.default : vs.name => vs.id }
+  )
+}
+
+# Get variable set IDs.
+data "tfe_variable_set" "default" {
+  for_each = var.variable_set_names
+
+  name = each.key
 }
 
 ################################################################################
@@ -124,7 +137,7 @@ resource "tfe_variable" "sensitive_hcl_variables" {
 }
 
 resource "tfe_workspace_variable_set" "default" {
-  for_each = var.variable_set_ids
+  for_each = local.variable_set_ids
 
   variable_set_id = each.value
   workspace_id    = tfe_workspace.default.id

--- a/modules/github-vcs/README.md
+++ b/modules/github-vcs/README.md
@@ -30,6 +30,83 @@ repository_files = {
 ```
 
 <!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | ~> 6.0 |
+| <a name="requirement_tfe"></a> [tfe](#requirement\_tfe) | ~> 0.66 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_github"></a> [github](#provider\_github) | ~> 6.0 |
+| <a name="provider_tfe"></a> [tfe](#provider\_tfe) | ~> 0.66 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_workspace"></a> [workspace](#module\_workspace) | ../.. | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [github_repository_file.backend](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
+| [github_repository_file.managed](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
+| [github_repository_file.unmanaged](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
+| [tfe_workspace_run.default](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/workspace_run) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_name"></a> [name](#input\_name) | A name for the Terraform workspace | `string` | n/a | yes |
+| <a name="input_repository_identifier"></a> [repository\_identifier](#input\_repository\_identifier) | The repository identifier to connect the workspace to | `string` | n/a | yes |
+| <a name="input_terraform_organization"></a> [terraform\_organization](#input\_terraform\_organization) | The Terraform organization to create the workspace in | `string` | n/a | yes |
+| <a name="input_agent_pool_id"></a> [agent\_pool\_id](#input\_agent\_pool\_id) | Agent pool ID, requires "execution\_mode" to be set to agent | `string` | `null` | no |
+| <a name="input_allow_destroy_plan"></a> [allow\_destroy\_plan](#input\_allow\_destroy\_plan) | Whether destroy plans can be queued on the workspace | `bool` | `true` | no |
+| <a name="input_assessments_enabled"></a> [assessments\_enabled](#input\_assessments\_enabled) | Whether to regularly run health assessments such as drift detection on the workspace | `bool` | `true` | no |
+| <a name="input_auto_apply"></a> [auto\_apply](#input\_auto\_apply) | Whether to automatically apply changes when a Terraform plan is successful | `bool` | `true` | no |
+| <a name="input_auto_apply_run_trigger"></a> [auto\_apply\_run\_trigger](#input\_auto\_apply\_run\_trigger) | Whether to automatically apply changes for runs that were created by run triggers from another workspace | `bool` | `false` | no |
+| <a name="input_backend_file_name"></a> [backend\_file\_name](#input\_backend\_file\_name) | The name of the backend file to create in the repository | `string` | `"backend.tf"` | no |
+| <a name="input_branch"></a> [branch](#input\_branch) | The git branch to trigger the TFE workspace for | `string` | `"main"` | no |
+| <a name="input_clear_text_env_variables"></a> [clear\_text\_env\_variables](#input\_clear\_text\_env\_variables) | An optional map with clear text environment variables | `map(string)` | `{}` | no |
+| <a name="input_clear_text_hcl_variables"></a> [clear\_text\_hcl\_variables](#input\_clear\_text\_hcl\_variables) | An optional map with clear text HCL Terraform variables | `map(string)` | `{}` | no |
+| <a name="input_clear_text_terraform_variables"></a> [clear\_text\_terraform\_variables](#input\_clear\_text\_terraform\_variables) | An optional map with clear text Terraform variables | `map(string)` | `{}` | no |
+| <a name="input_commit_author"></a> [commit\_author](#input\_commit\_author) | Committer author name to use. NOTE: GitHub app users may omit author and email information so GitHub can verify commits as the GitHub App. | `string` | `null` | no |
+| <a name="input_commit_email"></a> [commit\_email](#input\_commit\_email) | Committer email address to use. NOTE: GitHub app users may omit author and email information so GitHub can verify commits as the GitHub App. | `string` | `null` | no |
+| <a name="input_description"></a> [description](#input\_description) | A description for the workspace | `string` | `null` | no |
+| <a name="input_execution_mode"></a> [execution\_mode](#input\_execution\_mode) | Which execution mode to use | `string` | `"remote"` | no |
+| <a name="input_github_app_installation_id"></a> [github\_app\_installation\_id](#input\_github\_app\_installation\_id) | The GitHub App installation ID to use | `string` | `null` | no |
+| <a name="input_global_remote_state"></a> [global\_remote\_state](#input\_global\_remote\_state) | Allow all workspaces in the organization to read the state of this workspace | `bool` | `null` | no |
+| <a name="input_notification_configuration"></a> [notification\_configuration](#input\_notification\_configuration) | Notification configuration, using name as key and config as value | <pre>map(object({<br/>    destination_type = string<br/>    enabled          = optional(bool, true)<br/>    url              = string<br/>    triggers = optional(list(string), [<br/>      "run:created",<br/>      "run:planning",<br/>      "run:needs_attention",<br/>      "run:applying",<br/>      "run:completed",<br/>      "run:errored",<br/>    ])<br/>  }))</pre> | `{}` | no |
+| <a name="input_oauth_token_id"></a> [oauth\_token\_id](#input\_oauth\_token\_id) | The OAuth token ID of the VCS provider | `string` | `null` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of the project the workspace should be added to | `string` | `null` | no |
+| <a name="input_remote_state_consumer_ids"></a> [remote\_state\_consumer\_ids](#input\_remote\_state\_consumer\_ids) | A set of workspace IDs set as explicit remote state consumers for this workspace | `set(string)` | `null` | no |
+| <a name="input_repository_files"></a> [repository\_files](#input\_repository\_files) | A map of files that should be created in the workspace directory | <pre>map(object({<br/>    content = string<br/>    managed = optional(bool, true)<br/>  }))</pre> | `{}` | no |
+| <a name="input_sensitive_env_variables"></a> [sensitive\_env\_variables](#input\_sensitive\_env\_variables) | An optional map with sensitive environment variables | `map(string)` | `{}` | no |
+| <a name="input_sensitive_hcl_variables"></a> [sensitive\_hcl\_variables](#input\_sensitive\_hcl\_variables) | An optional map with sensitive HCL Terraform variables | <pre>map(object({<br/>    sensitive = string<br/>  }))</pre> | `{}` | no |
+| <a name="input_sensitive_terraform_variables"></a> [sensitive\_terraform\_variables](#input\_sensitive\_terraform\_variables) | An optional map with sensitive Terraform variables | `map(string)` | `{}` | no |
+| <a name="input_speculative_enabled"></a> [speculative\_enabled](#input\_speculative\_enabled) | Whether this workspace allows speculative plans. Setting this to false prevents HCP Terraform or the Terraform Enterprise instance from running plans on pull requests, which can improve security if the VCS repository is public or includes untrusted contributors. | `bool` | `true` | no |
+| <a name="input_ssh_key_id"></a> [ssh\_key\_id](#input\_ssh\_key\_id) | The SSH key ID to assign to the workspace | `string` | `null` | no |
+| <a name="input_team_access"></a> [team\_access](#input\_team\_access) | Map of team names and either type of fixed access or custom permissions to assign | <pre>map(object({<br/>    access = optional(string, null),<br/>    permissions = optional(object({<br/>      run_tasks         = bool<br/>      runs              = string<br/>      sentinel_mocks    = string<br/>      state_versions    = string<br/>      variables         = string<br/>      workspace_locking = bool<br/>    }), null)<br/>  }))</pre> | `{}` | no |
+| <a name="input_terraform_version"></a> [terraform\_version](#input\_terraform\_version) | The version of Terraform to use for this workspace | `string` | `"latest"` | no |
+| <a name="input_trigger_patterns"></a> [trigger\_patterns](#input\_trigger\_patterns) | List of glob patterns that describe the files Terraform Cloud monitors for changes. Trigger patterns are always appended to the root directory of the repository. Mutually exclusive with trigger-prefixes | `list(string)` | <pre>[<br/>  "modules/**/*"<br/>]</pre> | no |
+| <a name="input_variable_set_ids"></a> [variable\_set\_ids](#input\_variable\_set\_ids) | Map of variable set IDs to attach to the workspace | `map(string)` | `{}` | no |
+| <a name="input_variable_set_names"></a> [variable\_set\_names](#input\_variable\_set\_names) | Set of variable set names to attach to the workspace | `set(string)` | `[]` | no |
+| <a name="input_working_directory"></a> [working\_directory](#input\_working\_directory) | A relative path that Terraform will execute within | `string` | `"terraform"` | no |
+| <a name="input_workspace_tags"></a> [workspace\_tags](#input\_workspace\_tags) | A list of tag names for this workspace. Note that tags must only contain lowercase letters, numbers, colons, or hyphens | `list(string)` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_id"></a> [id](#output\_id) | HCP Terraform workspace ID |
+| <a name="output_name"></a> [name](#output\_name) | HCP Terraform workspace name |
 <!-- END_TF_DOCS -->
 
 ## License

--- a/modules/github-vcs/README.md
+++ b/modules/github-vcs/README.md
@@ -1,0 +1,51 @@
+# github-vcs
+
+This Terraform submodule builds on the root module to create an HCP Terraform workspace and connect it to a GitHub repository.
+
+It first writes a `backend.tf` file to the workspace directory in the GitHub repository, then creates and configures the workspace to use a VCS-driven workflow.
+
+## Usage
+
+The following variables are required to use this module:
+
+- `name`: A name for the Terraform workspace
+- `repository_identifier`: The repository identifier to connect the workspace to
+- `terraform_organization`: The Terraform organization to create the workspace in
+
+And you will need to set either of the following to configure the VCS workflow:
+
+- `github_app_installation_id`: The GitHub App installation ID to use
+- `oauth_token_id`: The OAuth token ID of the VCS provider
+
+## Adding additional files
+
+Additional files can be created by populating `var.repository_files`. If, for example, you wanted to generate a `README.md` in the repository so that it shows in the workspace, you could do so by adding:
+
+```hcl
+repository_files = {
+  "README.md" = {
+    content = file("${path.root}/files/README.md")
+  }
+}
+```
+
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->
+
+## License
+
+**Copyright:** Schuberg Philis
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/modules/github-vcs/main.tf
+++ b/modules/github-vcs/main.tf
@@ -9,10 +9,6 @@ resource "github_repository_file" "backend" {
     organization = var.terraform_organization,
     workspace    = var.name
   })
-
-  lifecycle {
-    ignore_changes = [commit_author, commit_email]
-  }
 }
 
 # Files created by this resource are fully managed. Any downstream updates will be replaced the
@@ -25,10 +21,6 @@ resource "github_repository_file" "managed" {
   content       = each.value.content
   file          = "${var.working_directory}/${each.key}"
   repository    = split("/", var.repository_identifier)[1]
-
-  lifecycle {
-    ignore_changes = [commit_author, commit_email]
-  }
 }
 
 # Files created by this resource are a one time action. Any downstream content changes will not be
@@ -43,7 +35,7 @@ resource "github_repository_file" "unmanaged" {
   repository    = split("/", var.repository_identifier)[1]
 
   lifecycle {
-    ignore_changes = [commit_author, commit_email, content]
+    ignore_changes = [content]
   }
 }
 

--- a/modules/github-vcs/main.tf
+++ b/modules/github-vcs/main.tf
@@ -1,0 +1,104 @@
+# Write our backend file to the workspace directory.
+resource "github_repository_file" "backend" {
+  commit_author = var.commit_author
+  commit_email  = var.commit_email
+  file          = "${var.working_directory}/${var.backend_file_name}"
+  repository    = split("/", var.repository_identifier)[1]
+
+  content = templatefile("${path.module}/../../templates/backends.tf.tpl", {
+    organization = var.terraform_organization,
+    workspace    = var.name
+  })
+
+  lifecycle {
+    ignore_changes = [commit_author, commit_email]
+  }
+}
+
+# Files created by this resource are fully managed. Any downstream updates will be replaced the
+# next time Terraform runs.
+resource "github_repository_file" "managed" {
+  for_each = { for k, v in var.repository_files : k => v if v.managed }
+
+  commit_author = var.commit_author
+  commit_email  = var.commit_email
+  content       = each.value.content
+  file          = "${var.working_directory}/${each.key}"
+  repository    = split("/", var.repository_identifier)[1]
+
+  lifecycle {
+    ignore_changes = [commit_author, commit_email]
+  }
+}
+
+# Files created by this resource are a one time action. Any downstream content changes will not be
+# overwritten. This helps to build a repository skeleton where you want some templating.
+resource "github_repository_file" "unmanaged" {
+  for_each = { for k, v in var.repository_files : k => v if !v.managed }
+
+  commit_author = var.commit_author
+  commit_email  = var.commit_email
+  content       = each.value.content
+  file          = "${var.working_directory}/${each.key}"
+  repository    = split("/", var.repository_identifier)[1]
+
+  lifecycle {
+    ignore_changes = [commit_author, commit_email, content]
+  }
+}
+
+# Create the workspace.
+module "workspace" {
+  source = "../.."
+
+  name                           = var.name
+  agent_pool_id                  = var.agent_pool_id
+  allow_destroy_plan             = var.allow_destroy_plan
+  assessments_enabled            = var.assessments_enabled
+  auto_apply                     = var.auto_apply
+  auto_apply_run_trigger         = var.auto_apply_run_trigger
+  branch                         = var.branch
+  clear_text_env_variables       = var.clear_text_env_variables
+  clear_text_hcl_variables       = var.clear_text_hcl_variables
+  clear_text_terraform_variables = var.clear_text_terraform_variables
+  description                    = var.description
+  execution_mode                 = var.execution_mode
+  file_triggers_enabled          = true # Changes to files trigger a plan.
+  github_app_installation_id     = var.github_app_installation_id
+  global_remote_state            = var.global_remote_state
+  notification_configuration     = var.notification_configuration
+  oauth_token_id                 = var.oauth_token_id
+  project_id                     = var.project_id
+  queue_all_runs                 = false # Prevent queuing a run before backend config is written.
+  remote_state_consumer_ids      = var.remote_state_consumer_ids
+  repository_identifier          = var.repository_identifier
+  sensitive_env_variables        = var.sensitive_env_variables
+  sensitive_hcl_variables        = var.sensitive_hcl_variables
+  sensitive_terraform_variables  = var.sensitive_terraform_variables
+  speculative_enabled            = var.speculative_enabled
+  ssh_key_id                     = var.ssh_key_id
+  team_access                    = var.team_access
+  terraform_organization         = var.terraform_organization
+  terraform_version              = var.terraform_version
+  trigger_patterns               = var.trigger_patterns
+  variable_set_ids               = var.variable_set_ids
+  variable_set_names             = var.variable_set_names
+  working_directory              = var.working_directory
+  workspace_tags                 = var.workspace_tags
+}
+
+# Queue a run in the created workspace after the backend and repository files have been created.
+resource "tfe_workspace_run" "default" {
+  workspace_id = module.workspace.id
+
+  depends_on = [
+    github_repository_file.backend,
+    github_repository_file.managed,
+    github_repository_file.unmanaged,
+  ]
+
+  apply {
+    manual_confirm = false
+    retry          = false
+  }
+}

--- a/modules/github-vcs/outputs.tf
+++ b/modules/github-vcs/outputs.tf
@@ -1,0 +1,9 @@
+output "id" {
+  value       = module.workspace.id
+  description = "HCP Terraform workspace ID"
+}
+
+output "name" {
+  value       = module.workspace.name
+  description = "HCP Terraform workspace name"
+}

--- a/modules/github-vcs/terraform.tf
+++ b/modules/github-vcs/terraform.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.0"
+    }
+    tfe = {
+      source  = "hashicorp/tfe"
+      version = "~> 0.66"
+    }
+  }
+  required_version = ">= 1.9"
+}

--- a/modules/github-vcs/variables.tf
+++ b/modules/github-vcs/variables.tf
@@ -18,7 +18,7 @@ variable "assessments_enabled" {
 
 variable "auto_apply" {
   type        = bool
-  default     = false
+  default     = true
   description = "Whether to automatically apply changes when a Terraform plan is successful"
 }
 
@@ -26,6 +26,12 @@ variable "auto_apply_run_trigger" {
   type        = bool
   default     = false
   description = "Whether to automatically apply changes for runs that were created by run triggers from another workspace"
+}
+
+variable "backend_file_name" {
+  type        = string
+  default     = "backend.tf"
+  description = "The name of the backend file to create in the repository"
 }
 
 variable "branch" {
@@ -52,6 +58,18 @@ variable "clear_text_terraform_variables" {
   description = "An optional map with clear text Terraform variables"
 }
 
+variable "commit_author" {
+  type        = string
+  default     = null
+  description = "Committer author name to use. NOTE: GitHub app users may omit author and email information so GitHub can verify commits as the GitHub App."
+}
+
+variable "commit_email" {
+  type        = string
+  default     = null
+  description = "Committer email address to use. NOTE: GitHub app users may omit author and email information so GitHub can verify commits as the GitHub App."
+}
+
 variable "description" {
   type        = string
   default     = null
@@ -67,12 +85,6 @@ variable "execution_mode" {
     condition     = var.execution_mode == "agent" || var.execution_mode == "local" || var.execution_mode == "remote"
     error_message = "The execution_mode value must be either \"agent\", \"local\", or \"remote\"."
   }
-}
-
-variable "file_triggers_enabled" {
-  type        = bool
-  default     = true
-  description = "Whether to filter runs based on the changed files in a VCS push"
 }
 
 variable "github_app_installation_id" {
@@ -128,21 +140,23 @@ variable "project_id" {
   description = "ID of the project the workspace should be added to"
 }
 
-variable "queue_all_runs" {
-  type        = bool
-  default     = true
-  description = "When set to false no initial run is queued and all runs triggered by a webhook will not be queued, necessary if you need to set variable sets after creation."
-}
-
 variable "remote_state_consumer_ids" {
   type        = set(string)
   default     = null
   description = "A set of workspace IDs set as explicit remote state consumers for this workspace"
 }
 
+variable "repository_files" {
+  type = map(object({
+    content = string
+    managed = optional(bool, true)
+  }))
+  default     = {}
+  description = "A map of files that should be created in the workspace directory"
+}
+
 variable "repository_identifier" {
   type        = string
-  default     = null
   description = "The repository identifier to connect the workspace to"
 }
 
@@ -169,7 +183,7 @@ variable "sensitive_terraform_variables" {
 variable "speculative_enabled" {
   type        = bool
   default     = true
-  description = "Whether this workspace allows speculative plans. Setting this to false prevents Terraform from running plans on pull requests."
+  description = "Whether this workspace allows speculative plans. Setting this to false prevents HCP Terraform or the Terraform Enterprise instance from running plans on pull requests, which can improve security if the VCS repository is public or includes untrusted contributors."
 }
 
 variable "ssh_key_id" {
@@ -217,12 +231,6 @@ variable "trigger_patterns" {
   description = "List of glob patterns that describe the files Terraform Cloud monitors for changes. Trigger patterns are always appended to the root directory of the repository. Mutually exclusive with trigger-prefixes"
 }
 
-variable "trigger_prefixes" {
-  type        = list(string)
-  default     = null
-  description = "(**DEPRECATED**) List of repository-root-relative paths which should be tracked for changes"
-}
-
 variable "variable_set_ids" {
   type        = map(string)
   default     = {}
@@ -231,7 +239,7 @@ variable "variable_set_ids" {
 
   validation {
     condition     = length(var.variable_set_ids) == 0 || length(var.variable_set_names) == 0
-    error_message = "You cannot use both variable_set_ids and variable_set_names at the same time."
+    error_message = "You cannot use both variable_set_ids and variable_set_names at the same time. Please use one of them."
   }
 }
 

--- a/modules/gitlab-vcs/README.md
+++ b/modules/gitlab-vcs/README.md
@@ -26,6 +26,83 @@ repository_files = {
 ```
 
 <!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
+| <a name="requirement_gitlab"></a> [gitlab](#requirement\_gitlab) | ~> 18.0 |
+| <a name="requirement_tfe"></a> [tfe](#requirement\_tfe) | ~> 0.66 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_gitlab"></a> [gitlab](#provider\_gitlab) | ~> 18.0 |
+| <a name="provider_tfe"></a> [tfe](#provider\_tfe) | ~> 0.66 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_workspace"></a> [workspace](#module\_workspace) | ../.. | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [gitlab_repository_file.backend](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/repository_file) | resource |
+| [gitlab_repository_file.managed](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/repository_file) | resource |
+| [gitlab_repository_file.unmanaged](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/repository_file) | resource |
+| [tfe_workspace_run.default](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/workspace_run) | resource |
+| [gitlab_project.default](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/data-sources/project) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_name"></a> [name](#input\_name) | A name for the Terraform workspace | `string` | n/a | yes |
+| <a name="input_oauth_token_id"></a> [oauth\_token\_id](#input\_oauth\_token\_id) | The OAuth token ID of the VCS provider | `string` | n/a | yes |
+| <a name="input_repository_identifier"></a> [repository\_identifier](#input\_repository\_identifier) | The repository identifier to connect the workspace to | `string` | n/a | yes |
+| <a name="input_terraform_organization"></a> [terraform\_organization](#input\_terraform\_organization) | The Terraform organization to create the workspace in | `string` | n/a | yes |
+| <a name="input_agent_pool_id"></a> [agent\_pool\_id](#input\_agent\_pool\_id) | Agent pool ID, requires "execution\_mode" to be set to agent | `string` | `null` | no |
+| <a name="input_allow_destroy_plan"></a> [allow\_destroy\_plan](#input\_allow\_destroy\_plan) | Whether destroy plans can be queued on the workspace | `bool` | `true` | no |
+| <a name="input_assessments_enabled"></a> [assessments\_enabled](#input\_assessments\_enabled) | Whether to regularly run health assessments such as drift detection on the workspace | `bool` | `true` | no |
+| <a name="input_auto_apply"></a> [auto\_apply](#input\_auto\_apply) | Whether to automatically apply changes when a Terraform plan is successful | `bool` | `true` | no |
+| <a name="input_auto_apply_run_trigger"></a> [auto\_apply\_run\_trigger](#input\_auto\_apply\_run\_trigger) | Whether to automatically apply changes for runs that were created by run triggers from another workspace | `bool` | `false` | no |
+| <a name="input_backend_file_name"></a> [backend\_file\_name](#input\_backend\_file\_name) | The name of the backend file to create in the repository | `string` | `"backend.tf"` | no |
+| <a name="input_branch"></a> [branch](#input\_branch) | The git branch to trigger the TFE workspace for | `string` | `"main"` | no |
+| <a name="input_clear_text_env_variables"></a> [clear\_text\_env\_variables](#input\_clear\_text\_env\_variables) | An optional map with clear text environment variables | `map(string)` | `{}` | no |
+| <a name="input_clear_text_hcl_variables"></a> [clear\_text\_hcl\_variables](#input\_clear\_text\_hcl\_variables) | An optional map with clear text HCL Terraform variables | `map(string)` | `{}` | no |
+| <a name="input_clear_text_terraform_variables"></a> [clear\_text\_terraform\_variables](#input\_clear\_text\_terraform\_variables) | An optional map with clear text Terraform variables | `map(string)` | `{}` | no |
+| <a name="input_commit_author"></a> [commit\_author](#input\_commit\_author) | Committer author name to use. | `string` | `null` | no |
+| <a name="input_commit_email"></a> [commit\_email](#input\_commit\_email) | Committer email address to use. | `string` | `null` | no |
+| <a name="input_description"></a> [description](#input\_description) | A description for the workspace | `string` | `null` | no |
+| <a name="input_execution_mode"></a> [execution\_mode](#input\_execution\_mode) | Which execution mode to use | `string` | `"remote"` | no |
+| <a name="input_global_remote_state"></a> [global\_remote\_state](#input\_global\_remote\_state) | Allow all workspaces in the organization to read the state of this workspace | `bool` | `null` | no |
+| <a name="input_notification_configuration"></a> [notification\_configuration](#input\_notification\_configuration) | Notification configuration, using name as key and config as value | <pre>map(object({<br/>    destination_type = string<br/>    enabled          = optional(bool, true)<br/>    url              = string<br/>    triggers = optional(list(string), [<br/>      "run:created",<br/>      "run:planning",<br/>      "run:needs_attention",<br/>      "run:applying",<br/>      "run:completed",<br/>      "run:errored",<br/>    ])<br/>  }))</pre> | `{}` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of the project the workspace should be added to | `string` | `null` | no |
+| <a name="input_remote_state_consumer_ids"></a> [remote\_state\_consumer\_ids](#input\_remote\_state\_consumer\_ids) | A set of workspace IDs set as explicit remote state consumers for this workspace | `set(string)` | `null` | no |
+| <a name="input_repository_files"></a> [repository\_files](#input\_repository\_files) | A map of files that should be created in the workspace directory | <pre>map(object({<br/>    content = string<br/>    managed = optional(bool, true)<br/>  }))</pre> | `{}` | no |
+| <a name="input_sensitive_env_variables"></a> [sensitive\_env\_variables](#input\_sensitive\_env\_variables) | An optional map with sensitive environment variables | `map(string)` | `{}` | no |
+| <a name="input_sensitive_hcl_variables"></a> [sensitive\_hcl\_variables](#input\_sensitive\_hcl\_variables) | An optional map with sensitive HCL Terraform variables | <pre>map(object({<br/>    sensitive = string<br/>  }))</pre> | `{}` | no |
+| <a name="input_sensitive_terraform_variables"></a> [sensitive\_terraform\_variables](#input\_sensitive\_terraform\_variables) | An optional map with sensitive Terraform variables | `map(string)` | `{}` | no |
+| <a name="input_speculative_enabled"></a> [speculative\_enabled](#input\_speculative\_enabled) | Whether this workspace allows speculative plans. Setting this to false prevents HCP Terraform or the Terraform Enterprise instance from running plans on pull requests, which can improve security if the VCS repository is public or includes untrusted contributors. | `bool` | `true` | no |
+| <a name="input_ssh_key_id"></a> [ssh\_key\_id](#input\_ssh\_key\_id) | The SSH key ID to assign to the workspace | `string` | `null` | no |
+| <a name="input_team_access"></a> [team\_access](#input\_team\_access) | Map of team names and either type of fixed access or custom permissions to assign | <pre>map(object({<br/>    access = optional(string, null),<br/>    permissions = optional(object({<br/>      run_tasks         = bool<br/>      runs              = string<br/>      sentinel_mocks    = string<br/>      state_versions    = string<br/>      variables         = string<br/>      workspace_locking = bool<br/>    }), null)<br/>  }))</pre> | `{}` | no |
+| <a name="input_terraform_version"></a> [terraform\_version](#input\_terraform\_version) | The version of Terraform to use for this workspace | `string` | `"latest"` | no |
+| <a name="input_trigger_patterns"></a> [trigger\_patterns](#input\_trigger\_patterns) | List of glob patterns that describe the files Terraform Cloud monitors for changes. Trigger patterns are always appended to the root directory of the repository. Mutually exclusive with trigger-prefixes | `list(string)` | <pre>[<br/>  "modules/**/*"<br/>]</pre> | no |
+| <a name="input_variable_set_ids"></a> [variable\_set\_ids](#input\_variable\_set\_ids) | Map of variable set IDs to attach to the workspace | `map(string)` | `{}` | no |
+| <a name="input_variable_set_names"></a> [variable\_set\_names](#input\_variable\_set\_names) | Set of variable set names to attach to the workspace | `set(string)` | `[]` | no |
+| <a name="input_working_directory"></a> [working\_directory](#input\_working\_directory) | A relative path that Terraform will execute within | `string` | `"terraform"` | no |
+| <a name="input_workspace_tags"></a> [workspace\_tags](#input\_workspace\_tags) | A list of tag names for this workspace. Note that tags must only contain lowercase letters, numbers, colons, or hyphens | `list(string)` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_id"></a> [id](#output\_id) | HCP Terraform workspace ID |
+| <a name="output_name"></a> [name](#output\_name) | HCP Terraform workspace name |
 <!-- END_TF_DOCS -->
 
 ## License

--- a/modules/gitlab-vcs/README.md
+++ b/modules/gitlab-vcs/README.md
@@ -1,0 +1,47 @@
+# gitlab-vcs
+
+This Terraform submodule builds on the root module to create an HCP Terraform workspace and connect it to a GitLab repository.
+
+It first writes a `backend.tf` file to the workspace directory in the GitLab repository, then creates and configures the workspace to use a VCS-driven workflow.
+
+## Usage
+
+The following variables are required to use this module:
+
+- `name`: A name for the Terraform workspace
+- `oauth_token_id`: The OAuth token ID of the VCS provider
+- `repository_identifier`: The repository identifier to connect the workspace to
+- `terraform_organization`: The Terraform organization to create the workspace in
+
+## Adding additional files
+
+Additional files can be created by populating `var.repository_files`. If, for example, you wanted to generate a `README.md` in the repository so that it shows in the workspace, you could do so by adding:
+
+```hcl
+repository_files = {
+  "README.md" = {
+    content = file("${path.root}/files/README.md")
+  }
+}
+```
+
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->
+
+## License
+
+**Copyright:** Schuberg Philis
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/modules/gitlab-vcs/main.tf
+++ b/modules/gitlab-vcs/main.tf
@@ -1,0 +1,122 @@
+# Write our backend file to the workspace directory.
+data "gitlab_project" "default" {
+  path_with_namespace = var.repository_identifier
+}
+
+resource "gitlab_repository_file" "backend" {
+  author_email          = var.commit_email
+  author_name           = var.commit_author
+  branch                = "main"
+  create_commit_message = "Created ${var.working_directory}/${var.backend_file_name}"
+  delete_commit_message = "Deleted ${var.working_directory}/${var.backend_file_name}"
+  encoding              = "text"
+  file_path             = "${var.working_directory}/${var.backend_file_name}"
+  project               = data.gitlab_project.default.id
+  update_commit_message = "Updated ${var.working_directory}/${var.backend_file_name}"
+
+  content = templatefile("${path.module}/../../templates/backends.tf.tpl", {
+    organization = var.terraform_organization,
+    workspace    = var.name
+  })
+
+  lifecycle {
+    ignore_changes = [author_email, author_name]
+  }
+}
+
+# Files created by this resource are fully managed. Any downstream updates will be replaced the
+# next time Terraform runs.
+resource "gitlab_repository_file" "managed" {
+  for_each = { for k, v in var.repository_files : k => v if v.managed }
+
+  author_email          = var.commit_email
+  author_name           = var.commit_author
+  branch                = "main"
+  content               = each.value.content
+  create_commit_message = "Created ${var.working_directory}/${var.backend_file_name}"
+  delete_commit_message = "Deleted ${var.working_directory}/${var.backend_file_name}"
+  encoding              = "text"
+  file_path             = "${var.working_directory}/${each.key}"
+  project               = data.gitlab_project.default.id
+  update_commit_message = "Updated ${var.working_directory}/${var.backend_file_name}"
+
+  lifecycle {
+    ignore_changes = [author_email, author_name]
+  }
+}
+
+# Files created by this resource are a one time action. Any downstream content changes will not be
+# overwritten. This helps to build a repository skeleton where you want some templating.
+resource "gitlab_repository_file" "unmanaged" {
+  for_each = { for k, v in var.repository_files : k => v if !v.managed }
+
+  author_email          = var.commit_email
+  author_name           = var.commit_author
+  branch                = "main"
+  content               = each.value.content
+  create_commit_message = "Created ${var.working_directory}/${var.backend_file_name}"
+  delete_commit_message = "Deleted ${var.working_directory}/${var.backend_file_name}"
+  encoding              = "text"
+  file_path             = "${var.working_directory}/${each.key}"
+  project               = data.gitlab_project.default.id
+  update_commit_message = "Updated ${var.working_directory}/${var.backend_file_name}"
+
+  lifecycle {
+    ignore_changes = [author_email, author_name, content]
+  }
+}
+
+# Create the workspace.
+module "workspace" {
+  source = "../.."
+
+  name                           = var.name
+  agent_pool_id                  = var.agent_pool_id
+  allow_destroy_plan             = var.allow_destroy_plan
+  assessments_enabled            = var.assessments_enabled
+  auto_apply                     = var.auto_apply
+  auto_apply_run_trigger         = var.auto_apply_run_trigger
+  branch                         = var.branch
+  clear_text_env_variables       = var.clear_text_env_variables
+  clear_text_hcl_variables       = var.clear_text_hcl_variables
+  clear_text_terraform_variables = var.clear_text_terraform_variables
+  description                    = var.description
+  execution_mode                 = var.execution_mode
+  file_triggers_enabled          = true # Changes to files trigger a plan.
+  global_remote_state            = var.global_remote_state
+  notification_configuration     = var.notification_configuration
+  oauth_token_id                 = var.oauth_token_id
+  project_id                     = var.project_id
+  queue_all_runs                 = false # Prevent queuing a run before backend config is written.
+  remote_state_consumer_ids      = var.remote_state_consumer_ids
+  repository_identifier          = var.repository_identifier
+  sensitive_env_variables        = var.sensitive_env_variables
+  sensitive_hcl_variables        = var.sensitive_hcl_variables
+  sensitive_terraform_variables  = var.sensitive_terraform_variables
+  speculative_enabled            = var.speculative_enabled
+  ssh_key_id                     = var.ssh_key_id
+  team_access                    = var.team_access
+  terraform_organization         = var.terraform_organization
+  terraform_version              = var.terraform_version
+  trigger_patterns               = var.trigger_patterns
+  variable_set_ids               = var.variable_set_ids
+  variable_set_names             = var.variable_set_names
+  working_directory              = var.working_directory
+  workspace_tags                 = var.workspace_tags
+}
+
+# Queue a run in the created workspace after the backend and repository files have been created.
+resource "tfe_workspace_run" "default" {
+  workspace_id = module.workspace.id
+
+  depends_on = [
+    gitlab_repository_file.backend,
+    gitlab_repository_file.managed,
+    gitlab_repository_file.unmanaged,
+  ]
+
+  apply {
+    manual_confirm = false
+    retry          = false
+  }
+}

--- a/modules/gitlab-vcs/main.tf
+++ b/modules/gitlab-vcs/main.tf
@@ -18,10 +18,6 @@ resource "gitlab_repository_file" "backend" {
     organization = var.terraform_organization,
     workspace    = var.name
   })
-
-  lifecycle {
-    ignore_changes = [author_email, author_name]
-  }
 }
 
 # Files created by this resource are fully managed. Any downstream updates will be replaced the
@@ -39,10 +35,6 @@ resource "gitlab_repository_file" "managed" {
   file_path             = "${var.working_directory}/${each.key}"
   project               = data.gitlab_project.default.id
   update_commit_message = "Updated ${var.working_directory}/${var.backend_file_name}"
-
-  lifecycle {
-    ignore_changes = [author_email, author_name]
-  }
 }
 
 # Files created by this resource are a one time action. Any downstream content changes will not be
@@ -62,7 +54,7 @@ resource "gitlab_repository_file" "unmanaged" {
   update_commit_message = "Updated ${var.working_directory}/${var.backend_file_name}"
 
   lifecycle {
-    ignore_changes = [author_email, author_name, content]
+    ignore_changes = [content]
   }
 }
 

--- a/modules/gitlab-vcs/outputs.tf
+++ b/modules/gitlab-vcs/outputs.tf
@@ -1,0 +1,9 @@
+output "id" {
+  value       = module.workspace.id
+  description = "HCP Terraform workspace ID"
+}
+
+output "name" {
+  value       = module.workspace.name
+  description = "HCP Terraform workspace name"
+}

--- a/modules/gitlab-vcs/terraform.tf
+++ b/modules/gitlab-vcs/terraform.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    gitlab = {
+      source  = "gitlabhq/gitlab"
+      version = "~> 18.0"
+    }
+    tfe = {
+      source  = "hashicorp/tfe"
+      version = "~> 0.66"
+    }
+  }
+  required_version = ">= 1.9"
+}

--- a/modules/gitlab-vcs/variables.tf
+++ b/modules/gitlab-vcs/variables.tf
@@ -18,7 +18,7 @@ variable "assessments_enabled" {
 
 variable "auto_apply" {
   type        = bool
-  default     = false
+  default     = true
   description = "Whether to automatically apply changes when a Terraform plan is successful"
 }
 
@@ -26,6 +26,12 @@ variable "auto_apply_run_trigger" {
   type        = bool
   default     = false
   description = "Whether to automatically apply changes for runs that were created by run triggers from another workspace"
+}
+
+variable "backend_file_name" {
+  type        = string
+  default     = "backend.tf"
+  description = "The name of the backend file to create in the repository"
 }
 
 variable "branch" {
@@ -52,6 +58,18 @@ variable "clear_text_terraform_variables" {
   description = "An optional map with clear text Terraform variables"
 }
 
+variable "commit_author" {
+  type        = string
+  default     = null
+  description = "Committer author name to use."
+}
+
+variable "commit_email" {
+  type        = string
+  default     = null
+  description = "Committer email address to use."
+}
+
 variable "description" {
   type        = string
   default     = null
@@ -67,18 +85,6 @@ variable "execution_mode" {
     condition     = var.execution_mode == "agent" || var.execution_mode == "local" || var.execution_mode == "remote"
     error_message = "The execution_mode value must be either \"agent\", \"local\", or \"remote\"."
   }
-}
-
-variable "file_triggers_enabled" {
-  type        = bool
-  default     = true
-  description = "Whether to filter runs based on the changed files in a VCS push"
-}
-
-variable "github_app_installation_id" {
-  type        = string
-  default     = null
-  description = "The GitHub App installation ID to use"
 }
 
 variable "global_remote_state" {
@@ -118,7 +124,6 @@ variable "notification_configuration" {
 
 variable "oauth_token_id" {
   type        = string
-  default     = null
   description = "The OAuth token ID of the VCS provider"
 }
 
@@ -128,21 +133,23 @@ variable "project_id" {
   description = "ID of the project the workspace should be added to"
 }
 
-variable "queue_all_runs" {
-  type        = bool
-  default     = true
-  description = "When set to false no initial run is queued and all runs triggered by a webhook will not be queued, necessary if you need to set variable sets after creation."
-}
-
 variable "remote_state_consumer_ids" {
   type        = set(string)
   default     = null
   description = "A set of workspace IDs set as explicit remote state consumers for this workspace"
 }
 
+variable "repository_files" {
+  type = map(object({
+    content = string
+    managed = optional(bool, true)
+  }))
+  default     = {}
+  description = "A map of files that should be created in the workspace directory"
+}
+
 variable "repository_identifier" {
   type        = string
-  default     = null
   description = "The repository identifier to connect the workspace to"
 }
 
@@ -169,7 +176,7 @@ variable "sensitive_terraform_variables" {
 variable "speculative_enabled" {
   type        = bool
   default     = true
-  description = "Whether this workspace allows speculative plans. Setting this to false prevents Terraform from running plans on pull requests."
+  description = "Whether this workspace allows speculative plans. Setting this to false prevents HCP Terraform or the Terraform Enterprise instance from running plans on pull requests, which can improve security if the VCS repository is public or includes untrusted contributors."
 }
 
 variable "ssh_key_id" {
@@ -217,12 +224,6 @@ variable "trigger_patterns" {
   description = "List of glob patterns that describe the files Terraform Cloud monitors for changes. Trigger patterns are always appended to the root directory of the repository. Mutually exclusive with trigger-prefixes"
 }
 
-variable "trigger_prefixes" {
-  type        = list(string)
-  default     = null
-  description = "(**DEPRECATED**) List of repository-root-relative paths which should be tracked for changes"
-}
-
 variable "variable_set_ids" {
   type        = map(string)
   default     = {}
@@ -231,7 +232,7 @@ variable "variable_set_ids" {
 
   validation {
     condition     = length(var.variable_set_ids) == 0 || length(var.variable_set_names) == 0
-    error_message = "You cannot use both variable_set_ids and variable_set_names at the same time."
+    error_message = "You cannot use both variable_set_ids and variable_set_names at the same time. Please use one of them."
   }
 }
 

--- a/templates/backends.tf.tpl
+++ b/templates/backends.tf.tpl
@@ -1,0 +1,11 @@
+# This file is managed by Terraform.
+
+terraform {
+  cloud {
+    organization = "${organization}"
+
+    workspaces {
+      name = "${workspace}"
+    }
+  }
+}


### PR DESCRIPTION
## :hammer_and_wrench: Summary

The `github-vcs` and `gitlab-vcs` submodules build on the root module by adding a `backend.tf` file to the specified repository and ensuring that Terraform runs only after this file is created, so the initial plan succeeds. Without this file, plans would fail—so it is always handled as part of calling the module. Bundling this logic within the module simplifies provisioning workspaces that use the VCS-driven workflow.

This commit also introduces `var.repository_files`, which allows consumers to stub additional files in the workspace repository, such as a README, default provider blocks, variables, and more. When specifying additional files Terraform will wait for these to be created before queuing the first run.

Additionally, we introduce `var.variable_set_names`, a list of strings representing variable set names to attach to the workspace. This helps avoid repetitive code when the variable sets are known in advance. The module resolves these names to IDs using a data resource and passes them to the root module. If variable sets are being created in the same configuration as this module, `variable_set_ids` should still be used to provide the actual IDs.

## :rocket: Motivation

In all environments we copy and paste this wrapper code to make sure the backend config is present so the workspace works as expected. This PR adds that code for GitHub and GitLab to prevent doing this further.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>