### PR TITLE
fix: Make `var.terraform_organization` optional

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -202,6 +202,7 @@ variable "team_access" {
 
 variable "terraform_organization" {
   type        = string
+  default     = null
   description = "The Terraform organization to create the workspace in"
 }
 


### PR DESCRIPTION
## :hammer_and_wrench: Summary

This variable doesn't need to be configured when it's set in the provider.

Not removing it from the submodules because we use that value in templates, and we cannot read that from the provider.

## :rocket: Motivation

Fixes #28

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>